### PR TITLE
[AMRAP-564] Change ifname can0 to can1

### DIFF
--- a/src/scbdriver/src/canif.hpp
+++ b/src/scbdriver/src/canif.hpp
@@ -43,6 +43,6 @@ public:
     int send(const can_frame &frame) const;
 private:
     std::function<void(const can_frame &frame)> handler{nullptr};
-    std::string ifname{"can0"};
+    std::string ifname{"can1"};
     int sock{-1};
 };


### PR DESCRIPTION
IPCとSCBDriverの間で通信するために、ifnameをcan0からcan1に変更。
v7で動作確認済

Change the ifname from can0 to can1 for communication between IPC and SCBDriver.
I have confirmed to work with v7.