### PR TITLE
HWDEV-1966 fix charging status code

### DIFF
--- a/src/receiver_board.cpp
+++ b/src/receiver_board.cpp
@@ -71,7 +71,7 @@ void receiver_board::publish_emergency(const can_frame &frame) const
 
 void receiver_board::publish_charge(const can_frame &frame) const
 {
-    static constexpr uint8_t MANUAL_CHARGE_STATE{6}, AUTO_CHARGE_STATE{5};
+    static constexpr uint8_t MANUAL_CHARGE_STATE{2}, AUTO_CHARGE_STATE{1};
     std_msgs::Byte msg;
     msg.data = frame.data[1] == MANUAL_CHARGE_STATE ? 2
              : frame.data[1] == AUTO_CHARGE_STATE   ? 1


### PR DESCRIPTION
Ref: [HWDEV-1966](https://lexxpluss.atlassian.net/browse/HWDEV-1966)

This PR is motivated to make a specification of the`charge state` field
in [this](https://docs.google.com/spreadsheets/d/1BUw1DyfwlZkW9h5lmsoH0C3u_8_Rs3ECtHGyzQDv7Ik/edit#gid=0) and follow it.

In this PR, `1` in `charge state` means `AUTO CHARGING` and `2` in `charge state` means `MANUAL CHARGE`.

[HWDEV-1966]: https://lexxpluss.atlassian.net/browse/HWDEV-1966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ