### PR TITLE
HWDEV-2046 use real bmu data

### DIFF
--- a/src/receiver_bmu.cpp
+++ b/src/receiver_bmu.cpp
@@ -94,12 +94,10 @@ void receiver_bmu::decode(scbdriver::Battery &msg) const
     msg.state.voltage = bmudata.pack_voltage * 1e-3f;
     msg.state.temperature = bmudata.fet_temp * 1e-2f;
     msg.state.current = bmudata.pack_current * 1e-2f;
-    //msg.state.charge = bmudata.remain_capacity * 1e-2f;
-    msg.state.charge = 99 * 1e-2f;  // TODO: for workaround
+    msg.state.charge = bmudata.remain_capacity * 1e-2f;
     msg.state.capacity = bmudata.full_charge_capacity * 1e-2f;
     msg.state.design_capacity = bmudata.design_capacity * 1e-2f;
-    //msg.state.percentage = bmudata.rsoc * 1e-2f;
-    msg.state.percentage = 99 * 1e-2f;  // TODO: for workaround
+    msg.state.percentage = bmudata.rsoc * 1e-2f;
     msg.state.power_supply_status =
         (bmudata.mod_status1 & 0b01000000) != 0 ? sensor_msgs::BatteryState::POWER_SUPPLY_STATUS_FULL
                      : msg.state.current > 0.0f ? sensor_msgs::BatteryState::POWER_SUPPLY_STATUS_CHARGING


### PR DESCRIPTION
Ref: [HWDEV-2046](https://lexxpluss.atlassian.net/browse/HWDEV-2046)

This PR is motivated to use real bmu data instead of its mock value. This PR remove mock value and comment out about using real bmu data.

This PR is check in real robot. And the result of this PR are following. You can see the valid `charge` and `percentage` in it.
![Screenshot from 2024-06-27 11-25-18](https://github.com/LexxPluss/LexxHard-SCBDriver/assets/2285892/0f964904-2d2f-49b3-8acd-5c34f674121d)


[HWDEV-2046]: https://lexxpluss.atlassian.net/browse/HWDEV-2046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ