### PR TITLE
Hwdev 1832 add ci workflow to scbdriver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install clang-format
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-format
+    - name: Run C++ linter
+      run: |
+        find . -name ‘*.h’ -or -name ‘*.hpp’ -or -name ‘*.cpp’ | xargs clang-format -i --style=file
+        git diff --exit-code
+  build_and_test:
+    needs: lint
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+    - name: Build Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: ./util/workspace
+        file: ./util/workspace/Dockerfile
+        push: false
+        load: true
+        tags: ros_workspace:latest
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    - name: Build ROS package
+      run: |
+        cd util/workspace
+        docker compose run --rm rosbuild

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         find . -name ‘*.h’ -or -name ‘*.hpp’ -or -name ‘*.cpp’ | xargs clang-format -i --style=file
         git diff --exit-code
-  build_and_test:
+  build:
     needs: lint
     runs-on: ubuntu-20.04
     steps:

--- a/README.md
+++ b/README.md
@@ -29,16 +29,11 @@
 ```shell
 host$ cd util/workspace
 host$ docker compose run --rm rosbuild
-docker# cd /space
-docker# catkin_make
 ```
 
 ## Exec on IPC
 
 ```shell
 host$ cd util/workspace
-host$ docker compose run --rm rosbuild
-docker# cd /space
-docker# source devel/setup.bash
-docker# roslaunch scbdriver scbdriver.launch
+host$ docker compose run --rm roslaunch
 ```

--- a/util/workspace/docker-compose.yml
+++ b/util/workspace/docker-compose.yml
@@ -24,9 +24,23 @@
 version: '3'
 services:
   rosbuild:
+    image: lexxhard_scbdriver
     build: .
     volumes:
       - ./:/space
       - ../../:/space/src/scbdriver
+    working_dir: /space
+    command: bash -c "source /opt/ros/noetic/setup.bash && catkin_make"
     network_mode: host
     privileged: true
+  roslaunch:
+    image: lexxhard_scbdriver
+    build: .
+    volumes:
+      - ./:/space
+      - ../../:/space/src/scbdriver
+    working_dir: /space
+    command: bash -c "source devel/setup.bash && roslaunch scbdriver scbdriver.launch"
+    network_mode: host
+    privileged: true
+


### PR DESCRIPTION
Ref: [HWDEV-1832](https://lexxpluss.atlassian.net/browse/HWDEV-1832)

This PR is motivated to add ci workflow and improve docker configurations. This PR contains following modifications

* Add CI workflow definition
* Improve `rosbuild` target in docker-compose.yml to run catkin_make automatically
*  Add `roslaunch` target to docker-compose.yml to launch scbdriver

[HWDEV-1832]: https://lexxpluss.atlassian.net/browse/HWDEV-1832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ