### PR TITLE
HWDEV-2079 add emergency_stop publisher

### DIFF
--- a/src/receiver_board.cpp
+++ b/src/receiver_board.cpp
@@ -33,7 +33,8 @@
 
 receiver_board::receiver_board(ros::NodeHandle &n)
     : pub_bumper{n.advertise<std_msgs::ByteMultiArray>("/sensor_set/bumper", queue_size)},
-      pub_emergency{n.advertise<std_msgs::Bool>("/sensor_set/emergency_switch", queue_size)},
+      pub_emergency_switch{n.advertise<std_msgs::Bool>("/sensor_set/emergency_switch", queue_size)},
+      pub_emergency_stop{n.advertise<std_msgs::Bool>("/body_control/emergency_stop", queue_size)},
       pub_charge{n.advertise<std_msgs::Byte>("/body_control/charge_status", queue_size)},
       pub_power{n.advertise<std_msgs::Byte>("/body_control/power_state", queue_size)},
       pub_charge_delay{n.advertise<std_msgs::UInt8>("/body_control/charge_heartbeat_delay", queue_size)},
@@ -46,7 +47,8 @@ void receiver_board::handle(const can_frame &frame) const
     if (frame.can_dlc != 6)
         return;
     publish_bumper(frame);
-    publish_emergency(frame);
+    publish_emergency_switch(frame);
+    publish_emergency_stop(frame);
     publish_charge(frame);
     publish_power(frame);
     publish_charge_delay(frame);
@@ -62,11 +64,18 @@ void receiver_board::publish_bumper(const can_frame &frame) const
     pub_bumper.publish(msg);
 }
 
-void receiver_board::publish_emergency(const can_frame &frame) const
+void receiver_board::publish_emergency_switch(const can_frame &frame) const
 {
     std_msgs::Bool msg;
     msg.data = (frame.data[0] & 0b00110000) != 0;
-    pub_emergency.publish(msg);
+    pub_emergency_switch.publish(msg);
+}
+
+void receiver_board::publish_emergency_stop(const can_frame &frame) const
+{
+    std_msgs::Bool msg;
+    msg.data = (frame.data[0] & 0b00000100) != 0;
+    pub_emergency_stop.publish(msg);
 }
 
 void receiver_board::publish_charge(const can_frame &frame) const

--- a/src/receiver_board.hpp
+++ b/src/receiver_board.hpp
@@ -35,13 +35,14 @@ public:
     void handle(const can_frame &frame) const;
 private:
     void publish_bumper(const can_frame &frame) const;
-    void publish_emergency(const can_frame &frame) const;
+    void publish_emergency_switch(const can_frame &frame) const;
+    void publish_emergency_stop(const can_frame &frame) const;
     void publish_charge(const can_frame &frame) const;
     void publish_power(const can_frame &frame) const;
     void publish_charge_delay(const can_frame &frame) const;
     void publish_charge_voltage(const can_frame &frame) const;
     ros::Publisher
-        pub_bumper, pub_emergency, pub_charge,
-        pub_power, pub_charge_delay, pub_charge_voltage;
+        pub_bumper, pub_emergency_switch, pub_emergency_stop,
+        pub_charge, pub_power, pub_charge_delay, pub_charge_voltage;
     static constexpr uint32_t queue_size{10};
 };


### PR DESCRIPTION
Ref: [HWDEV-2082](https://lexxpluss.atlassian.net/browse/HWDEV-2082)

This PR is motivated to add emergency_stop publisher. emergency_stop publisher is expected to transfer the emergency status which is sent from scb via can to ROS nodes. This PR contains following modifications.

* Rename variable pub_emergency to pub_emergency_switch. This renaming is only applied to variable name. So topic name is not changed.
* Add pub_emergency_stop to publish emergency status to a topic whose name is `/body_control/emergency_stop`.
* Add handler for emergency status

This codes are evaluated in real robot. And we could follwoing logs. It means that we could get the emergency status unexpectedly.

```
root@v70002:/space# rostopic echo /body_control/emergency_stop
data: False
---
data: False
---
data: False
---
data: False
---
data: False
---
data: False
---
data: False
---
data: False
---
data: False
---
data: True
---
data: True
---
data: True
```

[HWDEV-2082]: https://lexxpluss.atlassian.net/browse/HWDEV-2082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ