### PR TITLE
Hwdev 2176 add tug encoder handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(
   src/receiver_imu.cpp
   src/receiver_pgv.cpp
   src/receiver_uss.cpp
+  src/receiver_tug_encoder.cpp
 )
 add_executable(
   sender

--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -34,6 +34,7 @@
 #include "receiver_imu.hpp"
 #include "receiver_pgv.hpp"
 #include "receiver_uss.hpp"
+#include "receiver_tug_encoder.hpp"
 
 namespace {
 
@@ -76,6 +77,9 @@ public:
         case 0x20e:
             dfu.handle(frame);
             break;
+        case 0x210:
+            tug_encoder.handle(frame);
+            break;
         default:
             break;
         }
@@ -88,6 +92,7 @@ private:
     receiver_imu imu;
     receiver_pgv pgv;
     receiver_uss uss;
+    receiver_tug_encoder tug_encoder;
 };
 
 }
@@ -123,6 +128,7 @@ int main(int argc, char *argv[])
         {0x20a, CAN_SFF_MASK},
         {0x20c, CAN_SFF_MASK},
         {0x20e, CAN_SFF_MASK},
+        {0x210, CAN_SFF_MASK},
     };
     if (can.init(filter, sizeof filter) < 0) {
         std::cerr << "canif::init() failed" << std::endl;

--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -41,7 +41,7 @@ namespace {
 class handler {
 public:
     handler(ros::NodeHandle &n)
-        : actuator{n}, bmu{n}, board{n}, dfu{n}, imu{n}, pgv{n}, uss{n} {} 
+        : actuator{n}, bmu{n}, board{n}, dfu{n}, imu{n}, pgv{n}, uss{n}, tug_encoder{n} {}
     void handle(const can_frame &frame) {
         switch (frame.can_id) {
         case 0x100:

--- a/src/receiver_tug_encoder.cpp
+++ b/src/receiver_tug_encoder.cpp
@@ -40,6 +40,6 @@ void receiver_tug_encoder::handle(const can_frame &frame) const
     uint16_t const enc_value = static_cast<uint16_t>(frame.data[0]) << 8 | frame.data[1];
 
     std_msgs::Float32 msg;
-    msg.data = env_value * 360.0f / 4096.0f;
+    msg.data = enc_value;
     pub.publish(msg);
 }

--- a/src/receiver_tug_encoder.cpp
+++ b/src/receiver_tug_encoder.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, LexxPluss Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <linux/can.h>
+#include "std_msgs/Float32.h"
+#include "receiver_tug_encoder.hpp"
+
+receiver_tug_encoder::receiver_tug_encoder(ros::NodeHandle &n)
+    : pub{n.advertise<std_msgs::Float32>("/sensor_set/tug_encoder", queue_size)}
+{
+}
+
+void receiver_tug_encoder::handle(const can_frame &frame) const
+{
+    if (frame.can_dlc != 8)
+        return;
+
+    uint16_t const enc_value = static_cast<uint16_t>(frame.data[0]) << 8 | frame.data[1];
+
+    std_msgs::Float32 msg;
+    msg.data = env_value * 360.0f / 4096.0f;
+    pub.publish(msg);
+}

--- a/src/receiver_tug_encoder.cpp
+++ b/src/receiver_tug_encoder.cpp
@@ -34,7 +34,7 @@ receiver_tug_encoder::receiver_tug_encoder(ros::NodeHandle &n)
 
 void receiver_tug_encoder::handle(const can_frame &frame) const
 {
-    if (frame.can_dlc != 8)
+    if (frame.can_dlc != 2)
         return;
 
     uint16_t const enc_value = static_cast<uint16_t>(frame.data[0]) << 8 | frame.data[1];

--- a/src/receiver_tug_encoder.hpp
+++ b/src/receiver_tug_encoder.hpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, LexxPluss Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ros/ros.h"
+
+struct can_frame;
+
+class receiver_tug_encoder {
+public:
+    receiver_tug_encoder(ros::NodeHandle &n);
+    void handle(const can_frame &frame) const;
+private:
+    ros::Publisher pub;
+    static constexpr uint32_t queue_size{10};
+};


### PR DESCRIPTION
ref: [HWDEV-2176](https://lexxpluss.atlassian.net/browse/HWDEV-2176)

This PR is motivated to handle new tug encoder. This PR contains followings.

* Add receiver_tug_encoder which is designed for retrieving encoder value via CAN Bus.
* Add CAN MASK for encoder value whose id is 0x210

[HWDEV-2176]: https://lexxpluss.atlassian.net/browse/HWDEV-2176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ