### PR TITLE
Hwdev 2243 improve actuator control service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_message_files(
   Led.msg
   LinearActuatorControl.msg
   LinearActuatorControlArray.msg
+  LinearActuatorServiceResponse.msg
   PositionGuideVision.msg
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ add_message_files(
 add_service_files(
   FILES
   InitLinearActuator.srv
+  LinearActuatorLocation.srv
 )
 
 generate_messages(

--- a/msg/LinearActuatorServiceResponse.msg
+++ b/msg/LinearActuatorServiceResponse.msg
@@ -23,5 +23,5 @@
 
 uint8 mode
 bool success
-uint8[] details
+uint8[] detail
 uint8 counter

--- a/msg/LinearActuatorServiceResponse.msg
+++ b/msg/LinearActuatorServiceResponse.msg
@@ -1,0 +1,27 @@
+# Copyright (c) 2024, LexxPluss Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+uint8 mode
+bool success
+uint8[] details
+uint8 counter

--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -70,6 +70,7 @@ public:
             break;
         case 0x209:
         case 0x20a:
+        case 0x213:
             actuator.handle(frame);
             break;
         case 0x20c:
@@ -135,6 +136,7 @@ int main(int argc, char *argv[])
         {0x20e, CAN_SFF_MASK},
         {0x210, CAN_SFF_MASK},
         {0x212, CAN_SFF_MASK},
+        {0x213, CAN_SFF_MASK},
     };
     if (can.init(filter, sizeof filter) < 0) {
         std::cerr << "canif::init() failed" << std::endl;

--- a/src/receiver_actuator.cpp
+++ b/src/receiver_actuator.cpp
@@ -94,7 +94,7 @@ void receiver_actuator::handle_service_response(const can_frame &frame) const
 
     scbdriver::LinearActuatorServiceResponse msg;
     msg.mode = frame.data[0];
-    msg.success = frame.data[1] == 0;
+    msg.success = frame.data[1] == 1;
     msg.detail.resize(3);
     msg.detail[0] = frame.data[2];
     msg.detail[1] = frame.data[3];

--- a/src/receiver_actuator.cpp
+++ b/src/receiver_actuator.cpp
@@ -43,7 +43,7 @@ void receiver_actuator::handle(const can_frame &frame) const
         handle_encoder_count(frame);
     } else if (frame.can_id == 0x20a) {
         handle_current(frame);
-    } else if (frame.can_id == 0x20b) {
+    } else if (frame.can_id == 0x213) {
         handle_service_response(frame);
     }
 }

--- a/src/receiver_actuator.cpp
+++ b/src/receiver_actuator.cpp
@@ -95,10 +95,10 @@ void receiver_actuator::handle_service_response(const can_frame &frame) const
     scbdriver::LinearActuatorServiceResponse msg;
     msg.mode = frame.data[0];
     msg.success = frame.data[1] == 0;
-    msg.details.resize(3);
-    msg.details[0] = frame.data[2];
-    msg.details[1] = frame.data[3];
-    msg.details[2] = frame.data[4];
+    msg.detail.resize(3);
+    msg.detail[0] = frame.data[2];
+    msg.detail[1] = frame.data[3];
+    msg.detail[2] = frame.data[4];
     msg.counter = frame.data[7];
 
     pub_src_resp.publish(msg);

--- a/src/receiver_actuator.cpp
+++ b/src/receiver_actuator.cpp
@@ -33,7 +33,7 @@ receiver_actuator::receiver_actuator(ros::NodeHandle &n)
     : pub_encoder{n.advertise<std_msgs::Int32MultiArray>("/body_control/encoder_count", queue_size)},
       pub_current{n.advertise<std_msgs::Float32MultiArray>("/body_control/linear_actuator_current", queue_size)},
       pub_connection{n.advertise<std_msgs::Float32MultiArray>("/body_control/shelf_connection", queue_size)},
-      pub_src_resp{n.advertise<scbdriver::LinearActuatorServiceResponse>("/body_control/linear_actuator_service_response", queue_size)}
+      pub_src_resp{n.advertise<scbdriver::LinearActuatorServiceResponse>("scbdriver/linear_actuator_service_response", queue_size)}
 {
 }
 

--- a/src/receiver_actuator.hpp
+++ b/src/receiver_actuator.hpp
@@ -34,6 +34,13 @@ public:
     receiver_actuator(ros::NodeHandle &n);
     void handle(const can_frame &frame) const;
 private:
-    ros::Publisher pub_encoder, pub_current, pub_connection;
+    ros::Publisher pub_encoder;
+    ros::Publisher pub_current;
+    ros::Publisher pub_connection;
+    ros::Publisher pub_src_resp;
     static constexpr uint32_t queue_size{10};
+
+    void handle_encoder_count(const can_frame &frame) const;
+    void handle_current(const can_frame &frame) const;
+    void handle_service_response(const can_frame &frame) const;
 };

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
     sender_gpio gpio{n, can};
     sender_led led{n, can};
     sender_pgv pgv{n, can};
-    ros::MultiThreadedSpinner spinner{2};
+    ros::MultiThreadedSpinner spinner{3};
     spinner.spin();
     can.term();
     return 0;

--- a/src/sender_actuator.cpp
+++ b/src/sender_actuator.cpp
@@ -67,6 +67,7 @@ void sender_actuator::handle(const scbdriver::LinearActuatorControlArray::ConstP
 void sender_actuator::handle_srv_resp(const scbdriver::LinearActuatorServiceResponse::ConstPtr& msg)
 {
     resp_msg_store.insert(*msg);
+    service_resp_cv.notify_all();
 }
 
 bool sender_actuator::handle_init(

--- a/src/sender_actuator.cpp
+++ b/src/sender_actuator.cpp
@@ -36,7 +36,6 @@
 
 sender_actuator::sender_actuator(ros::NodeHandle &n, canif &can)
     : sub_actuator{n.subscribe("/body_control/linear_actuator", queue_size, &sender_actuator::handle, this)},
-      sub_encoder{n.subscribe("/body_control/encoder_count", queue_size, &sender_actuator::handle_encoder, this)},
       sub_srv_resp{n.subscribe("/body_control/linear_actuator_service_response", queue_size, &sender_actuator::handle_srv_resp, this)},
       srv_init{n.advertiseService("/body_control/init_linear_actuator", &sender_actuator::handle_init, this)},
       srv_location{n.advertiseService("/body_control/linear_actuator_location", &sender_actuator::handle_location, this)},
@@ -63,13 +62,6 @@ void sender_actuator::handle(const scbdriver::LinearActuatorControlArray::ConstP
     frame.data[4] = msg->actuators[0].power;
     frame.data[5] = msg->actuators[2].power;
     can.send(frame);
-}
-
-void sender_actuator::handle_encoder(const std_msgs::Int32MultiArray::ConstPtr& msg)
-{
-    encoder[0] = msg->data[1];
-    encoder[1] = msg->data[0];
-    encoder[2] = msg->data[2];
 }
 
 void sender_actuator::handle_srv_resp(const scbdriver::LinearActuatorServiceResponse::ConstPtr& msg)

--- a/src/sender_actuator.cpp
+++ b/src/sender_actuator.cpp
@@ -45,6 +45,11 @@ sender_actuator::sender_actuator(ros::NodeHandle &n, canif &can)
 
 void sender_actuator::handle(const scbdriver::LinearActuatorControlArray::ConstPtr &msg)
 {
+    if (msg->actuators.size() != 3) {
+        ROS_WARN("Drop message with invalid size");
+        return;
+    }
+
     std::unique_lock<std::mutex> lock{actuator_control_mtx, std::try_to_lock};
     if (!lock.owns_lock()) {
         return;
@@ -108,6 +113,15 @@ bool sender_actuator::handle_location(
     scbdriver::LinearActuatorLocation::Request& req,
     scbdriver::LinearActuatorLocation::Response& res)
 {
+    if (req.location.data.size() != 3 ) {
+        ROS_WARN("Invalid location request");
+        return false;
+    }
+    if (req.power.data.size() != 3 ) {
+        ROS_WARN("Invalid power request");
+        return false;
+    }
+
     std::unique_lock<std::mutex> lock(actuator_control_mtx, std::try_to_lock);
     if (!lock.owns_lock()) {
         return false;

--- a/src/sender_actuator.cpp
+++ b/src/sender_actuator.cpp
@@ -114,11 +114,11 @@ bool sender_actuator::handle_location(
     scbdriver::LinearActuatorLocation::Response& res)
 {
     if (req.location.data.size() != 3 ) {
-        ROS_WARN("Invalid location request");
+        ROS_WARN("Invalid location request: %lu", req.location.data.size());
         return false;
     }
     if (req.power.data.size() != 3 ) {
-        ROS_WARN("Invalid power request");
+        ROS_WARN("Invalid power request: %lu", req.power.data.size());
         return false;
     }
 

--- a/src/sender_actuator.cpp
+++ b/src/sender_actuator.cpp
@@ -23,22 +23,34 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <mutex>
+#include <optional>
+#include <condition_variable>
+#include <map>
+#include <chrono>
+
 #include <linux/can.h>
 #include "canif.hpp"
+#include "scbdriver/LinearActuatorServiceResponse.h"
 #include "sender_actuator.hpp"
 
 sender_actuator::sender_actuator(ros::NodeHandle &n, canif &can)
     : sub_actuator{n.subscribe("/body_control/linear_actuator", queue_size, &sender_actuator::handle, this)},
       sub_encoder{n.subscribe("/body_control/encoder_count", queue_size, &sender_actuator::handle_encoder, this)},
-      srv_actuator{n.advertiseService("/body_control/init_linear_actuator", &sender_actuator::handle_init, this)},
+      sub_srv_resp{n.subscribe("/body_control/linear_actuator_service_response", queue_size, &sender_actuator::handle_srv_resp, this)},
+      srv_init{n.advertiseService("/body_control/init_linear_actuator", &sender_actuator::handle_init, this)},
+      srv_location{n.advertiseService("/body_control/linear_actuator_location", &sender_actuator::handle_location, this)},
       can{can}
 {
 }
 
-void sender_actuator::handle(const scbdriver::LinearActuatorControlArray::ConstPtr &msg) const
+void sender_actuator::handle(const scbdriver::LinearActuatorControlArray::ConstPtr &msg)
 {
-    if (in_service)
+    std::unique_lock<std::mutex> lock{actuator_control_mtx, std::try_to_lock};
+    if (!lock.owns_lock()) {
         return;
+    }
+
     can_frame frame{
         .can_id{0x208},
         .can_dlc{6},
@@ -60,27 +72,105 @@ void sender_actuator::handle_encoder(const std_msgs::Int32MultiArray::ConstPtr& 
     encoder[2] = msg->data[2];
 }
 
+void sender_actuator::handle_srv_resp(const scbdriver::LinearActuatorServiceResponse::ConstPtr& msg)
+{
+    resp_msg_store.insert(*msg);
+}
+
 bool sender_actuator::handle_init(
     scbdriver::InitLinearActuator::Request& req,
     scbdriver::InitLinearActuator::Response& res)
 {
-    in_service = true;
-    can_frame frame{
-        .can_id{0x20b},
-        .can_dlc{1},
-    };
-    frame.data[0] = -1;
-    for (int i{0}, count{0}; i < 10; ++i) {
-        can.send(frame);
-        sleep(1);
-        if (encoder[0] == 0 && encoder[1] == 0 && encoder[2] == 0)
-            ++count;
-        else
-            count = 0;
-        if (count >= 3)
-            break;
+    std::unique_lock<std::mutex> lock(actuator_control_mtx, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        return false;
     }
-    res.success = encoder[0] == 0 && encoder[1] == 0 && encoder[2] == 0;
-    in_service = false;
+
+    auto const request_id = counter++;
+    // send request
+    {
+        can_frame frame{
+            .can_id{0x20b},
+            .can_dlc{8},
+        };
+        frame.data[0] = -1;  // -1 means init
+        frame.data[7] = request_id;
+
+        can.send(frame);
+    }
+
+    // wait for response
+    {
+        auto const resp{wait_for_service_response(lock, request_id)};
+        if (!resp.has_value()) {
+            return false;
+        }
+
+        res.success = resp->success;
+    }
     return true;
 }
+
+bool sender_actuator::handle_location(
+    scbdriver::LinearActuatorLocation::Request& req,
+    scbdriver::LinearActuatorLocation::Response& res)
+{
+    std::unique_lock<std::mutex> lock(actuator_control_mtx, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        return false;
+    }
+
+    auto const request_id = counter++;
+    // send request
+    {
+        can_frame frame{
+            .can_id{0x20b},
+            .can_dlc{8},
+        };
+        frame.data[0] = 0;  // 0 means location
+        frame.data[1] = req.location.data[1];
+        frame.data[2] = req.location.data[0];
+        frame.data[3] = req.location.data[2];
+        frame.data[4] = req.power.data[1];
+        frame.data[5] = req.power.data[0];
+        frame.data[6] = req.power.data[2];
+        frame.data[7] = request_id;
+
+        can.send(frame);
+    }
+
+    // wait for response
+    {
+        auto const resp{wait_for_service_response(lock, request_id)};
+        if (!resp.has_value()) {
+            return false;
+        }
+
+        res.success = resp->success;
+        res.detail.data.resize(3);
+        res.detail.data[0] = resp->detail[1];
+        res.detail.data[1] = resp->detail[0];
+        res.detail.data[2] = resp->detail[2];
+    }
+
+    return true;
+}
+
+std::optional<scbdriver::LinearActuatorServiceResponse> sender_actuator::wait_for_service_response(
+    std::unique_lock<std::mutex>& lock,
+    uint8_t counter
+) {
+    service_response_message_store::container_type::node_type node;
+    auto const is_done{service_resp_cv.wait_for(lock, service_response_timeout, [this, &counter, &node] {
+        node = resp_msg_store.extract(counter);
+        return !node.empty();
+    })};
+    if (!is_done) {
+        ROS_ERROR("Timeout waiting for response");
+        return std::nullopt;
+    }
+
+    // node own data because service was done
+    return node.mapped();
+}
+

--- a/src/sender_actuator.cpp
+++ b/src/sender_actuator.cpp
@@ -37,7 +37,7 @@
 
 sender_actuator::sender_actuator(ros::NodeHandle &n, canif &can)
     : sub_actuator{n.subscribe("/body_control/linear_actuator", queue_size, &sender_actuator::handle, this)},
-      sub_srv_resp{n.subscribe("/body_control/linear_actuator_service_response", queue_size, &sender_actuator::handle_srv_resp, this)},
+      sub_srv_resp{n.subscribe("scbdriver/linear_actuator_service_response", queue_size, &sender_actuator::handle_srv_resp, this)},
       srv_init{n.advertiseService("/body_control/init_linear_actuator", &sender_actuator::handle_init, this)},
       srv_location{n.advertiseService("/body_control/linear_actuator_location", &sender_actuator::handle_location, this)},
       can{can}

--- a/src/sender_actuator.cpp
+++ b/src/sender_actuator.cpp
@@ -121,6 +121,7 @@ bool sender_actuator::handle_location(
             .can_dlc{8},
         };
         frame.data[0] = 0;  // 0 means location
+        // ROS:[center,left,right], ROBOT:[left,center,right]
         frame.data[1] = req.location.data[1];
         frame.data[2] = req.location.data[0];
         frame.data[3] = req.location.data[2];
@@ -141,6 +142,7 @@ bool sender_actuator::handle_location(
 
         res.success = resp->success;
         res.detail.data.resize(3);
+        // ROS:[center,left,right], ROBOT:[left,center,right]
         res.detail.data[0] = resp->detail[1];
         res.detail.data[1] = resp->detail[0];
         res.detail.data[2] = resp->detail[2];
@@ -166,4 +168,3 @@ std::optional<scbdriver::LinearActuatorServiceResponse> sender_actuator::wait_fo
     // node own data because service was done
     return node.mapped();
 }
-

--- a/src/sender_actuator.cpp
+++ b/src/sender_actuator.cpp
@@ -30,6 +30,7 @@
 #include <chrono>
 
 #include <linux/can.h>
+
 #include "canif.hpp"
 #include "scbdriver/LinearActuatorServiceResponse.h"
 #include "sender_actuator.hpp"
@@ -46,7 +47,7 @@ sender_actuator::sender_actuator(ros::NodeHandle &n, canif &can)
 void sender_actuator::handle(const scbdriver::LinearActuatorControlArray::ConstPtr &msg)
 {
     if (msg->actuators.size() != 3) {
-        ROS_WARN("Drop message with invalid size");
+        ROS_WARN("Drop message with invalid size: %lu", msg->actuators.size());
         return;
     }
 
@@ -114,11 +115,11 @@ bool sender_actuator::handle_location(
     scbdriver::LinearActuatorLocation::Response& res)
 {
     if (req.location.data.size() != 3 ) {
-        ROS_WARN("Invalid location request: %lu", req.location.data.size());
+        ROS_WARN("Reject request with invalid location size: %lu", req.location.data.size());
         return false;
     }
     if (req.power.data.size() != 3 ) {
-        ROS_WARN("Invalid power request: %lu", req.power.data.size());
+        ROS_WARN("Reject request with invalid power size: %lu", req.power.data.size());
         return false;
     }
 
@@ -175,7 +176,7 @@ std::optional<scbdriver::LinearActuatorServiceResponse> sender_actuator::wait_fo
         return !node.empty();
     })};
     if (!is_done) {
-        ROS_ERROR("Timeout waiting for response");
+        ROS_ERROR("Timeout waiting for service response");
         return std::nullopt;
     }
 

--- a/src/sender_actuator.hpp
+++ b/src/sender_actuator.hpp
@@ -67,7 +67,6 @@ private:
     };
 
     void handle(const scbdriver::LinearActuatorControlArray::ConstPtr& msg);
-    void handle_encoder(const std_msgs::Int32MultiArray::ConstPtr& msg);
     void handle_srv_resp(const scbdriver::LinearActuatorServiceResponse::ConstPtr& msg);
     bool handle_init(
         scbdriver::InitLinearActuator::Request& req,
@@ -79,12 +78,10 @@ private:
         std::unique_lock<std::mutex>& lock,
         uint8_t counter);
     ros::Subscriber sub_actuator;
-    ros::Subscriber sub_encoder;
     ros::Subscriber sub_srv_resp;
     ros::ServiceServer srv_init;
     ros::ServiceServer srv_location;
     canif &can;
-    int32_t encoder[3]{0, 0, 0};
     std::mutex actuator_control_mtx;
     std::condition_variable service_resp_cv;
     service_response_message_store  resp_msg_store;

--- a/src/sender_actuator.hpp
+++ b/src/sender_actuator.hpp
@@ -25,10 +25,18 @@
 
 #pragma once
 
+#include <mutex>
+#include <optional>
+#include <condition_variable>
+#include <map>
+#include <chrono>
+
 #include "ros/ros.h"
 #include "std_msgs/Int32MultiArray.h"
 #include "scbdriver/InitLinearActuator.h"
+#include "scbdriver/LinearActuatorLocation.h"
 #include "scbdriver/LinearActuatorControlArray.h"
+#include "scbdriver/LinearActuatorServiceResponse.h"
 
 class canif;
 
@@ -36,15 +44,51 @@ class sender_actuator {
 public:
     sender_actuator(ros::NodeHandle &n, canif &can);
 private:
-    void handle(const scbdriver::LinearActuatorControlArray::ConstPtr& msg) const;
+    class service_response_message_store {
+    public:
+        using value_type = scbdriver::LinearActuatorServiceResponse;
+        using container_type = std::map<uint8_t, value_type>;
+
+        void insert(value_type const& msg)
+        {
+            std::lock_guard<std::mutex> lock{mtx};
+            store[msg.counter] = msg;
+        }
+
+        container_type::node_type extract(uint8_t counter)
+        {
+            std::lock_guard<std::mutex> lock{mtx};
+            return store.extract(counter);
+        }
+
+    private:
+        container_type store;
+        std::mutex mtx;
+    };
+
+    void handle(const scbdriver::LinearActuatorControlArray::ConstPtr& msg);
     void handle_encoder(const std_msgs::Int32MultiArray::ConstPtr& msg);
+    void handle_srv_resp(const scbdriver::LinearActuatorServiceResponse::ConstPtr& msg);
     bool handle_init(
         scbdriver::InitLinearActuator::Request& req,
         scbdriver::InitLinearActuator::Response& res);
-    ros::Subscriber sub_actuator, sub_encoder;
-    ros::ServiceServer srv_actuator;
+    bool handle_location(
+        scbdriver::LinearActuatorLocation::Request& req,
+        scbdriver::LinearActuatorLocation::Response& res);
+    std::optional<scbdriver::LinearActuatorServiceResponse> wait_for_service_response(
+        std::unique_lock<std::mutex>& lock,
+        uint8_t counter);
+    ros::Subscriber sub_actuator;
+    ros::Subscriber sub_encoder;
+    ros::Subscriber sub_srv_resp;
+    ros::ServiceServer srv_init;
+    ros::ServiceServer srv_location;
     canif &can;
     int32_t encoder[3]{0, 0, 0};
-    bool in_service{false};
+    std::mutex actuator_control_mtx;
+    std::condition_variable service_resp_cv;
+    service_response_message_store  resp_msg_store;
+    uint8_t counter{0};
     static constexpr uint32_t queue_size{10};
+    static constexpr std::chrono::seconds service_response_timeout{10};
 };

--- a/srv/LinearActuatorLocation.srv
+++ b/srv/LinearActuatorLocation.srv
@@ -1,0 +1,5 @@
+std_msgs/UInt8MultiArray location
+std_msgs/UInt8MultiArray power
+---
+bool success
+std_msgs/UInt8MultiArray detail


### PR DESCRIPTION
ref: [HWDEV-2243](https://lexxpluss.atlassian.net/browse/HWDEV-2243)

This PR is motivated to support controlling actuators by specifying location. To achieve this motivation, this PR added new service whose name is `/body_control/linear_actuator_location` to control actuator by specifying locatin. `/body_control/linear_actuator_location` service works with following steps.

1. Create a actuator service request can message whose id is 0x20b by transferring data from received service request.
2. Send above message to can bus.
3. Wait until service response received. This response is obtained by subscribing a topic whose name is `scbdriver/linear_actuator_service_response`
4. Set service result int response object

Waiting until service response received is implemented by using conditional variable. This means that subscriber thread can notify an event about service response received to service provider thread.

To achieve above, this PR contains followings.

* Add a message to handle response of actuator control
* Add a service whose name is `/body_control/linear_actuator_location` to control actuator by specified location
* Add a publisher whose name is `scbdriver/linear_actuator_service_response` to publish the result of actuator control. This topic is expected only to use in scbdriver.
* Add some argument check
* Increase the number of threads of sender not to stall when the actuator controlling service wait until its response.

[HWDEV-2243]: https://lexxpluss.atlassian.net/browse/HWDEV-2243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ