### PR TITLE
HWDEV-2161 fix encoder output type

### DIFF
--- a/src/receiver_tug_encoder.cpp
+++ b/src/receiver_tug_encoder.cpp
@@ -24,11 +24,11 @@
  */
 
 #include <linux/can.h>
-#include "std_msgs/Float32.h"
+#include "std_msgs/UInt32.h"
 #include "receiver_tug_encoder.hpp"
 
 receiver_tug_encoder::receiver_tug_encoder(ros::NodeHandle &n)
-    : pub{n.advertise<std_msgs::Float32>("/sensor_set/tug_encoder", queue_size)}
+    : pub{n.advertise<std_msgs::UInt32>("/sensor_set/tug_encoder", queue_size)}
 {
 }
 
@@ -39,7 +39,7 @@ void receiver_tug_encoder::handle(const can_frame &frame) const
 
     uint16_t const enc_value = static_cast<uint16_t>(frame.data[0]) << 8 | frame.data[1];
 
-    std_msgs::Float32 msg;
+    std_msgs::UInt32 msg;
     msg.data = enc_value;
     pub.publish(msg);
 }


### PR DESCRIPTION
ref: [HWDEV-2161](https://lexxpluss.atlassian.net/browse/HWDEV-2161)

This PR is motivated to fix output type of encoder value from Float32 to UInt32.

[HWDEV-2161]: https://lexxpluss.atlassian.net/browse/HWDEV-2161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ