### PR TITLE
HWDEV-2092 publish safety lidar output

### DIFF
--- a/src/receiver_board.cpp
+++ b/src/receiver_board.cpp
@@ -115,5 +115,5 @@ void receiver_board::publish_safety_lidar(const can_frame &frame) const
 {
     std_msgs::Bool msg;
     msg.data = (frame.data[0] & 0b00000010) != 0;
-    pub_bumper.publish(msg);
+    pub_safety_lidar.publish(msg);
 }

--- a/src/receiver_board.cpp
+++ b/src/receiver_board.cpp
@@ -38,7 +38,8 @@ receiver_board::receiver_board(ros::NodeHandle &n)
       pub_charge{n.advertise<std_msgs::Byte>("/body_control/charge_status", queue_size)},
       pub_power{n.advertise<std_msgs::Byte>("/body_control/power_state", queue_size)},
       pub_charge_delay{n.advertise<std_msgs::UInt8>("/body_control/charge_heartbeat_delay", queue_size)},
-      pub_charge_voltage{n.advertise<std_msgs::Float32>("/body_control/charge_connector_voltage", queue_size)}
+      pub_charge_voltage{n.advertise<std_msgs::Float32>("/body_control/charge_connector_voltage", queue_size)},
+      pub_safety_lidar{n.advertise<std_msgs::Bool>("/sensor_set/safety_lidar", queue_size)}
 {
 }
 
@@ -53,6 +54,7 @@ void receiver_board::handle(const can_frame &frame) const
     publish_power(frame);
     publish_charge_delay(frame);
     publish_charge_voltage(frame);
+    publish_safety_lidar(frame);
 }
 
 void receiver_board::publish_bumper(const can_frame &frame) const
@@ -107,4 +109,11 @@ void receiver_board::publish_charge_voltage(const can_frame &frame) const
     std_msgs::Float32 msg;
     msg.data = ((frame.data[4] << 8) | frame.data[5]) * 1e-3f;
     pub_charge_voltage.publish(msg);
+}
+
+void receiver_board::publish_safety_lidar(const can_frame &frame) const
+{
+    std_msgs::Bool msg;
+    msg.data = (frame.data[0] & 0b00000010) != 0;
+    pub_bumper.publish(msg);
 }

--- a/src/receiver_board.hpp
+++ b/src/receiver_board.hpp
@@ -41,8 +41,10 @@ private:
     void publish_power(const can_frame &frame) const;
     void publish_charge_delay(const can_frame &frame) const;
     void publish_charge_voltage(const can_frame &frame) const;
+    void publish_safety_lidar(const can_frame &frame) const;
     ros::Publisher
         pub_bumper, pub_emergency_switch, pub_emergency_stop,
-        pub_charge, pub_power, pub_charge_delay, pub_charge_voltage;
+        pub_charge, pub_power, pub_charge_delay, pub_charge_voltage,
+        pub_safety_lidar;
     static constexpr uint32_t queue_size{10};
 };


### PR DESCRIPTION
ref: [HWDEV-2092](https://lexxpluss.atlassian.net/browse/HWDEV-2092)

This PR is motivated to publish safety lidar status. This PR contains followings.

* Publish safety lidar emergency output as `/sensor_set/sfety_lidar`

This PR is checked in robot. And I got following logs.

There are not anything in danger area 
```
---
data: False
---
data: False
```

There are  something in danger area 
```
---
data: True
---
data: True
```

[HWDEV-2092]: https://lexxpluss.atlassian.net/browse/HWDEV-2092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ