### PR TITLE
Hwdev 2286 invert actuator direction for tug

### DIFF
--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -41,8 +41,8 @@ namespace {
 
 class handler {
 public:
-    handler(ros::NodeHandle &n)
-        : actuator{n}, bmu{n}, board{n}, dfu{n}, imu{n}, pgv{n}, uss{n}, gpio{n}, tug_encoder{n} {}
+    handler(ros::NodeHandle &n,ros::NodeHandle &pn)
+        : actuator{n, pn}, bmu{n}, board{n}, dfu{n}, imu{n}, pgv{n}, uss{n}, gpio{n}, tug_encoder{n} {}
     void handle(const can_frame &frame) {
         switch (frame.can_id) {
         case 0x100:
@@ -107,7 +107,8 @@ int main(int argc, char *argv[])
 {
     ros::init(argc, argv, "receiver");
     ros::NodeHandle n;
-    handler handler{n};
+    ros::NodeHandle pn("~");
+    handler handler{n, pn};
     canif can;
     can.set_handler(
         [&](const can_frame &frame) {

--- a/src/receiver_actuator.cpp
+++ b/src/receiver_actuator.cpp
@@ -72,8 +72,8 @@ void receiver_actuator::handle_encoder_count(const can_frame &frame) const
         return;
     // ROS:[center,left,right], ROBOT:[left,center,right]
     int16_t
-        L{static_cast<int16_t>((frame.data[0] << 8) | frame.data[1])},
-        C{static_cast<int16_t>((frame.data[2] << 8) | frame.data[3])},
+        C{static_cast<int16_t>((frame.data[0] << 8) | frame.data[1])},
+        L{static_cast<int16_t>((frame.data[2] << 8) | frame.data[3])},
         R{static_cast<int16_t>((frame.data[4] << 8) | frame.data[5])};
     std_msgs::Int32MultiArray msg;
     msg.data.resize(3);
@@ -89,8 +89,8 @@ void receiver_actuator::handle_current(const can_frame &frame) const
         return;
     // ROS:[center,left,right], ROBOT:[left,center,right]
     int16_t
-        L{static_cast<int16_t>((frame.data[0] << 8) | frame.data[1])},
-        C{static_cast<int16_t>((frame.data[2] << 8) | frame.data[3])},
+        C{static_cast<int16_t>((frame.data[0] << 8) | frame.data[1])},
+        L{static_cast<int16_t>((frame.data[2] << 8) | frame.data[3])},
         R{static_cast<int16_t>((frame.data[4] << 8) | frame.data[5])};
     std_msgs::Float32MultiArray msg_current;
     msg_current.data.resize(3);

--- a/src/receiver_actuator.cpp
+++ b/src/receiver_actuator.cpp
@@ -29,15 +29,15 @@
 #include "scbdriver/LinearActuatorServiceResponse.h"
 #include "receiver_actuator.hpp"
 
-receiver_actuator::receiver_actuator(ros::NodeHandle &n)
+receiver_actuator::receiver_actuator(ros::NodeHandle &n, ros::NodeHandle &pn)
     : pub_encoder{n.advertise<std_msgs::Int32MultiArray>("/body_control/encoder_count", queue_size)},
       pub_current{n.advertise<std_msgs::Float32MultiArray>("/body_control/linear_actuator_current", queue_size)},
       pub_connection{n.advertise<std_msgs::Float32MultiArray>("/body_control/shelf_connection", queue_size)},
       pub_src_resp{n.advertise<scbdriver::LinearActuatorServiceResponse>("scbdriver/linear_actuator_service_response", queue_size)}
 {
-    n.param<bool>("invert_center_actuator_direction", invert_center_actuator_direction,false);
-    n.param<bool>("invert_left_actuator_direction", invert_left_actuator_direction,false);
-    n.param<bool>("invert_right_actuator_direction", invert_right_actuator_direction,false);
+    pn.param<bool>("invert_center_actuator_direction", invert_center_actuator_direction,false);
+    pn.param<bool>("invert_left_actuator_direction", invert_left_actuator_direction,false);
+    pn.param<bool>("invert_right_actuator_direction", invert_right_actuator_direction,false);
 }
 
 int16_t receiver_actuator::adjust_encoder_count(size_t index, int16_t count) const

--- a/src/receiver_actuator.hpp
+++ b/src/receiver_actuator.hpp
@@ -38,9 +38,14 @@ private:
     ros::Publisher pub_current;
     ros::Publisher pub_connection;
     ros::Publisher pub_src_resp;
+    bool invert_center_actuator_direction;
+    bool invert_left_actuator_direction;
+    bool invert_right_actuator_direction;
+
     static constexpr uint32_t queue_size{10};
 
     void handle_encoder_count(const can_frame &frame) const;
     void handle_current(const can_frame &frame) const;
     void handle_service_response(const can_frame &frame) const;
+    int16_t adjust_encoder_count(size_t indx, int16_t count) const;
 };

--- a/src/receiver_actuator.hpp
+++ b/src/receiver_actuator.hpp
@@ -31,7 +31,7 @@ struct can_frame;
 
 class receiver_actuator {
 public:
-    receiver_actuator(ros::NodeHandle &n);
+    receiver_actuator(ros::NodeHandle &n, ros::NodeHandle &pn);
     void handle(const can_frame &frame) const;
 private:
     ros::Publisher pub_encoder;

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -37,12 +37,13 @@ int main(int argc, char *argv[])
 {
     ros::init(argc, argv, "sender");
     ros::NodeHandle n;
+    ros::NodeHandle pn("~");
     canif can;
     if (can.init(nullptr, 0) < 0) {
         std::cerr << "canif::init() failed" << std::endl;
         return -1;
     }
-    sender_actuator actuator{n, can};
+    sender_actuator actuator{n, pn, can};
     sender_board board{n, can};
     sender_dfu dfu{n, can};
     sender_gpio gpio{n, can};

--- a/src/sender_actuator.cpp
+++ b/src/sender_actuator.cpp
@@ -35,16 +35,16 @@
 #include "scbdriver/LinearActuatorServiceResponse.h"
 #include "sender_actuator.hpp"
 
-sender_actuator::sender_actuator(ros::NodeHandle &n, canif &can)
+sender_actuator::sender_actuator(ros::NodeHandle &n, ros::NodeHandle &pn, canif &can)
     : sub_actuator{n.subscribe("/body_control/linear_actuator", queue_size, &sender_actuator::handle, this)},
       sub_srv_resp{n.subscribe("scbdriver/linear_actuator_service_response", queue_size, &sender_actuator::handle_srv_resp, this)},
       srv_init{n.advertiseService("/body_control/init_linear_actuator", &sender_actuator::handle_init, this)},
       srv_location{n.advertiseService("/body_control/linear_actuator_location", &sender_actuator::handle_location, this)},
       can{can}
 {
-    n.param<bool>("invert_center_actuator_direction", invert_center_actuator_direction,false);
-    n.param<bool>("invert_left_actuator_direction", invert_left_actuator_direction,false);
-    n.param<bool>("invert_right_actuator_direction", invert_right_actuator_direction,false);
+    pn.param<bool>("invert_center_actuator_direction", invert_center_actuator_direction,false);
+    pn.param<bool>("invert_left_actuator_direction", invert_left_actuator_direction,false);
+    pn.param<bool>("invert_right_actuator_direction", invert_right_actuator_direction,false);
 }
 
 int8_t sender_actuator::adjust_direction(size_t index, int8_t direction) const

--- a/src/sender_actuator.cpp
+++ b/src/sender_actuator.cpp
@@ -79,8 +79,8 @@ void sender_actuator::handle(const scbdriver::LinearActuatorControlArray::ConstP
         .can_dlc{6},
     };
     // ROS:[center,left,right], ROBOT:[left,center,right]
-    frame.data[0] = adjust_direction(1, msg->actuators[1].direction);
-    frame.data[1] = adjust_direction(0, msg->actuators[0].direction);
+    frame.data[0] = adjust_direction(0, msg->actuators[1].direction);
+    frame.data[1] = adjust_direction(1, msg->actuators[0].direction);
     frame.data[2] = adjust_direction(2, msg->actuators[2].direction);
     frame.data[3] = msg->actuators[1].power;
     frame.data[4] = msg->actuators[0].power;

--- a/src/sender_actuator.cpp
+++ b/src/sender_actuator.cpp
@@ -78,12 +78,11 @@ void sender_actuator::handle(const scbdriver::LinearActuatorControlArray::ConstP
         .can_id{0x208},
         .can_dlc{6},
     };
-    // ROS:[center,left,right], ROBOT:[left,center,right]
-    frame.data[0] = adjust_direction(0, msg->actuators[1].direction);
-    frame.data[1] = adjust_direction(1, msg->actuators[0].direction);
+    frame.data[0] = adjust_direction(0, msg->actuators[0].direction);
+    frame.data[1] = adjust_direction(1, msg->actuators[1].direction);
     frame.data[2] = adjust_direction(2, msg->actuators[2].direction);
-    frame.data[3] = msg->actuators[1].power;
-    frame.data[4] = msg->actuators[0].power;
+    frame.data[3] = msg->actuators[0].power;
+    frame.data[4] = msg->actuators[1].power;
     frame.data[5] = msg->actuators[2].power;
     can.send(frame);
 }
@@ -157,12 +156,11 @@ bool sender_actuator::handle_location(
             .can_dlc{8},
         };
         frame.data[0] = 0;  // 0 means location
-        // ROS:[center,left,right], ROBOT:[left,center,right]
-        frame.data[1] = adjust_direction(0, req.location.data[1]);
-        frame.data[2] = adjust_direction(1, req.location.data[0]);
+        frame.data[1] = adjust_direction(0, req.location.data[0]);
+        frame.data[2] = adjust_direction(1, req.location.data[1]);
         frame.data[3] = adjust_direction(2, req.location.data[2]);
-        frame.data[4] = req.power.data[1];
-        frame.data[5] = req.power.data[0];
+        frame.data[4] = req.power.data[0];
+        frame.data[5] = req.power.data[1];
         frame.data[6] = req.power.data[2];
         frame.data[7] = request_id;
 
@@ -178,9 +176,8 @@ bool sender_actuator::handle_location(
 
         res.success = resp->success;
         res.detail.data.resize(3);
-        // ROS:[center,left,right], ROBOT:[left,center,right]
-        res.detail.data[0] = resp->detail[1];
-        res.detail.data[1] = resp->detail[0];
+        res.detail.data[0] = resp->detail[0];
+        res.detail.data[1] = resp->detail[1];
         res.detail.data[2] = resp->detail[2];
     }
 

--- a/src/sender_actuator.cpp
+++ b/src/sender_actuator.cpp
@@ -69,8 +69,8 @@ void sender_actuator::handle(const scbdriver::LinearActuatorControlArray::ConstP
         return;
     }
 
-    std::unique_lock<std::mutex> lock{actuator_control_mtx, std::try_to_lock};
-    if (!lock.owns_lock()) {
+    std::unique_lock<std::mutex> handle_lock{handle_mtx, std::try_to_lock};
+    if (!handle_lock.owns_lock()) {
         return;
     }
 
@@ -97,8 +97,8 @@ bool sender_actuator::handle_init(
     scbdriver::InitLinearActuator::Request& req,
     scbdriver::InitLinearActuator::Response& res)
 {
-    std::unique_lock<std::mutex> lock(actuator_control_mtx, std::try_to_lock);
-    if (!lock.owns_lock()) {
+    std::unique_lock<std::mutex> handle_lock{handle_mtx, std::try_to_lock};
+    if (!handle_lock.owns_lock()) {
         return false;
     }
 
@@ -120,7 +120,8 @@ bool sender_actuator::handle_init(
 
     // wait for response
     {
-        auto const resp{wait_for_service_response(lock, request_id)};
+        std::unique_lock<std::mutex> notify_lock{notify_mtx};
+        auto const resp{wait_for_service_response(notify_lock, request_id)};
         if (!resp.has_value()) {
             return false;
         }
@@ -143,8 +144,8 @@ bool sender_actuator::handle_location(
         return false;
     }
 
-    std::unique_lock<std::mutex> lock(actuator_control_mtx, std::try_to_lock);
-    if (!lock.owns_lock()) {
+    std::unique_lock<std::mutex> handle_lock{handle_mtx, std::try_to_lock};
+    if (!handle_lock.owns_lock()) {
         return false;
     }
 
@@ -169,7 +170,8 @@ bool sender_actuator::handle_location(
 
     // wait for response
     {
-        auto const resp{wait_for_service_response(lock, request_id)};
+        std::unique_lock<std::mutex> notify_lock{notify_mtx};
+        auto const resp{wait_for_service_response(notify_lock, request_id)};
         if (!resp.has_value()) {
             return false;
         }

--- a/src/sender_actuator.hpp
+++ b/src/sender_actuator.hpp
@@ -42,7 +42,7 @@ class canif;
 
 class sender_actuator {
 public:
-    sender_actuator(ros::NodeHandle &n, canif &can);
+    sender_actuator(ros::NodeHandle &n, ros::NodeHandle &pn, canif &can);
 private:
     class service_response_message_store {
     public:

--- a/src/sender_actuator.hpp
+++ b/src/sender_actuator.hpp
@@ -84,7 +84,8 @@ private:
     ros::ServiceServer srv_init;
     ros::ServiceServer srv_location;
     canif &can;
-    std::mutex actuator_control_mtx;
+    std::mutex handle_mtx;
+    std::mutex notify_mtx;
     std::condition_variable service_resp_cv;
     service_response_message_store  resp_msg_store;
     uint8_t counter{0};

--- a/src/sender_actuator.hpp
+++ b/src/sender_actuator.hpp
@@ -77,6 +77,8 @@ private:
     std::optional<scbdriver::LinearActuatorServiceResponse> wait_for_service_response(
         std::unique_lock<std::mutex>& lock,
         uint8_t counter);
+
+    int8_t adjust_direction(size_t index, int8_t direction) const;
     ros::Subscriber sub_actuator;
     ros::Subscriber sub_srv_resp;
     ros::ServiceServer srv_init;
@@ -86,6 +88,10 @@ private:
     std::condition_variable service_resp_cv;
     service_response_message_store  resp_msg_store;
     uint8_t counter{0};
+    bool invert_center_actuator_direction;
+    bool invert_left_actuator_direction;
+    bool invert_right_actuator_direction;
+
     static constexpr uint32_t queue_size{10};
     static constexpr std::chrono::seconds service_response_timeout{10};
 };


### PR DESCRIPTION
ref: [HWDEV-2286](https://lexxpluss.atlassian.net/browse/HWDEV-2286)

In v6, some actuator's direction are inverted to handle tug. So this PR is motivated to emulate this behavior by software. This PR contains followings.

* Add new NodeHandle to handle private parameters which are used for specifying actuator's direction inverted or not.
* Invert initialize direction if invert_(right|left|center)_actuator_direction is  true
* Multiply -1 with encoder value if invert_(right|left|center)_actuator_direction is true
* Multiply -1 with direction value if invert_(right|left|center)_actuator_direction is true
* Multiply -1 with location value if invert_(right|left|center)_actuator_direction is true
* Use CLR actuator order in can message
* Add a mutex for using conditional variable. The former implementation has a bug about using conditional variable. In detail, `wait_for` unlock given lock. 

The results of this PR are followings. In the following logs, invert_center_actuator_direction is true.

**initialize**

call rosservice
```
root@v71es007:/space# rosservice call /body_control/init_linear_actuator "{}"
success: True
```

act info after above service called
```
uart:~$ act info
[notice] parameter order [Center] [Left] [Right]
actuator: 0 encoder: 0 pulse current: 2 mV fail: 0 dir: 0 duty: 0
actuator: 1 encoder: 0 pulse current: 0 mV fail: 0 dir: 0 duty: 0
actuator: 2 encoder: 0 pulse current: 0 mV fail: 0 dir: 0 duty: 0
```

encoder value from /body_control/encoder_value
```
layout:
  dim: []
  data_offset: 0
data: [0, 0, 0]
---
```

**specify location**

service call
```
root@v71es007:/space# rosservice call /body_control/linear_actuator_location "location:
  layout:
    dim:
    - label: ''
      size: 3
      stride: 1
    data_offset: 0
  data: [20, 20, 20] ""
power:
  layout:
    dim:
    - label: ''
      size: 3
      stride: 1
    data_offset: 0
  data: [100, 100, 100] """
success: True
detail:
  layout:
    dim: []
    data_offset: 0
  data: [0, 0, 0]
```

act info after above service called
```
uart:~$ act info
[notice] parameter order [Center] [Left] [Right]
actuator: 0 encoder: -58 pulse current: 2 mV fail: 0 dir: 0 duty: 0
actuator: 1 encoder: 58 pulse current: 0 mV fail: 0 dir: 0 duty: 0
actuator: 2 encoder: 58 pulse current: 0 mV fail: 0 dir: 0 duty: 0
```

encoder value from /body_control/encoder_value. The following shows that the sign of center actuator value is inverted.
```
layout:
  dim: []
  data_offset: 0
data: [58, 58, 58]
---
```

**specify direction**

publish request
```
root@v71es007:/space# (reverse-i-search)`dire': rostopic pub /body_control/linear_actuator scbdriver/LinearActuatorControlArray "actuators:
- direction: 1
  power: 100
- direction: 1
  power: 100
- direction: 1
  power: 100
"
```

act info after actuator moving finished
```
uart:~$ act info
[notice] parameter order [Center] [Left] [Right]
actuator: 0 encoder: -267 pulse current: 2 mV fail: 0 dir: -1 duty: 100
actuator: 1 encoder: 270 pulse current: 2 mV fail: 0 dir: 1 duty: 100
actuator: 2 encoder: 265 pulse current: 2 mV fail: 0 dir: 1 duty: 100
```

encoder value from /body_control/encoder_value. The following shows that the sign of center actuator value is inverted.

```
layout:
  dim: []
  data_offset: 0
data: [267, 270, 265]
---
```


[HWDEV-2286]: https://lexxpluss.atlassian.net/browse/HWDEV-2286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ