### PR TITLE
AMRCS-465 install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,3 +113,10 @@ target_link_libraries(sender
 target_link_libraries(updater
   ${catkin_LIBRARIES}
 )
+
+install(TARGETS receiver
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+install(TARGETS sender
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)


### PR DESCRIPTION
ref: [AMRCS-465](https://lexxpluss.atlassian.net/browse/AMRCS-465)

This PR is motivated to add install targets about sender and receiver. And I checked that test version hybrid-amr-release works whose version is v1.7.4-v7-hybridamr-release-test-1 

[AMRCS-465]: https://lexxpluss.atlassian.net/browse/AMRCS-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ