### PR TITLE
AMRSW-1112 publish emergency_state

### DIFF
--- a/src/receiver_board.cpp
+++ b/src/receiver_board.cpp
@@ -34,7 +34,7 @@
 receiver_board::receiver_board(ros::NodeHandle& n)
   : pub_bumper{ n.advertise<std_msgs::ByteMultiArray>("/sensor_set/bumper", queue_size) }
   , pub_emergency_switch{ n.advertise<std_msgs::Bool>("/sensor_set/emergency_switch", queue_size) }
-  , pub_emergency_stop{ n.advertise<std_msgs::Bool>("/body_control/emergency_stop", queue_size) }
+  , pub_emergency_state{ n.advertise<std_msgs::Bool>("/body_control/emergency_state", queue_size) }
   , pub_charge{ n.advertise<std_msgs::Byte>("/body_control/charge_status", queue_size) }
   , pub_power{ n.advertise<std_msgs::Byte>("/body_control/power_state", queue_size) }
   , pub_charge_delay{ n.advertise<std_msgs::UInt8>("/body_control/charge_heartbeat_delay", queue_size) }
@@ -49,7 +49,7 @@ void receiver_board::handle(const can_frame& frame) const
     return;
   publish_bumper(frame);
   publish_emergency_switch(frame);
-  publish_emergency_stop(frame);
+  publish_emergency_state(frame);
   publish_charge(frame);
   publish_power(frame);
   publish_charge_delay(frame);
@@ -73,11 +73,11 @@ void receiver_board::publish_emergency_switch(const can_frame& frame) const
   pub_emergency_switch.publish(msg);
 }
 
-void receiver_board::publish_emergency_stop(const can_frame& frame) const
+void receiver_board::publish_emergency_state(const can_frame& frame) const
 {
   std_msgs::Bool msg;
   msg.data = (frame.data[0] & 0b00000100) != 0;
-  pub_emergency_stop.publish(msg);
+  pub_emergency_state.publish(msg);
 }
 
 void receiver_board::publish_charge(const can_frame& frame) const

--- a/src/receiver_board.hpp
+++ b/src/receiver_board.hpp
@@ -38,13 +38,13 @@ public:
 private:
   void publish_bumper(const can_frame& frame) const;
   void publish_emergency_switch(const can_frame& frame) const;
-  void publish_emergency_stop(const can_frame& frame) const;
+  void publish_emergency_state(const can_frame& frame) const;
   void publish_charge(const can_frame& frame) const;
   void publish_power(const can_frame& frame) const;
   void publish_charge_delay(const can_frame& frame) const;
   void publish_charge_voltage(const can_frame& frame) const;
   void publish_safety_lidar(const can_frame& frame) const;
-  ros::Publisher pub_bumper, pub_emergency_switch, pub_emergency_stop, pub_charge, pub_power, pub_charge_delay,
+  ros::Publisher pub_bumper, pub_emergency_switch, pub_emergency_state, pub_charge, pub_power, pub_charge_delay,
       pub_charge_voltage, pub_safety_lidar;
   static constexpr uint32_t queue_size{ 10 };
 };


### PR DESCRIPTION
ref: [](https://lexxpluss.atlassian.net/browse/AMRSW-1112)

This PR is motivated to publish `emergency_state` instead of `emergency_stop` . This  modification is derived from `https://github.com/LexxPluss/LexxHard-SensorControlBoard-Firmware/pull/62`