### PR TITLE
[AMRSW: 1248]Update "emergency_stop" keyword to "safety_pause"

### DIFF
--- a/src/sender_led.cpp
+++ b/src/sender_led.cpp
@@ -53,7 +53,7 @@ void sender_led::handle(const std_msgs::String::ConstPtr& msg) const
 void sender_led::decode(const std::string& data, uint8_t& pattern, uint16_t& count_per_minutes, uint8_t rgb[3]) const
 {
   // The following patterns are fixed
-  if (data == "emergency_stop")
+  if (data == "safety_pause")
     pattern = 1;
   else if (data == "amr_mode")
     pattern = 2;


### PR DESCRIPTION
Replaced occurrences of "emergency_stop" with "safety_pause" in the sender_led and led_controller logic. This improves terminology consistency and better reflects the intended functionality.