### PR TITLE
feat/AMRSW-2054 publish temperature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ add_message_files(
   LinearActuatorControlArray.msg
   LinearActuatorServiceResponse.msg
   PositionGuideVision.msg
+  BoardTemperatures.msg
 )
 
 add_service_files(

--- a/msg/BoardTemperatures.msg
+++ b/msg/BoardTemperatures.msg
@@ -1,0 +1,30 @@
+# Copyright (c) 2024, LexxPluss Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+sensor_msgs/Temperature main
+sensor_msgs/Temperature power
+sensor_msgs/Temperature linear_actuator_center
+sensor_msgs/Temperature linear_actuator_left
+sensor_msgs/Temperature linear_actuator_right
+sensor_msgs/Temperature charge_plus
+sensor_msgs/Temperature charge_minus

--- a/src/receiver_bmu.cpp
+++ b/src/receiver_bmu.cpp
@@ -140,4 +140,5 @@ void receiver_bmu::decode(scbdriver::Battery& msg) const
   msg.state.cell_temperature[1] = bmudata.min_temp.value * 1e-2f;
   msg.state.location = "0";
   msg.state.serial_number = os.str();
+  msg.state_of_health = bmudata.soh;
 }

--- a/src/receiver_board.hpp
+++ b/src/receiver_board.hpp
@@ -44,7 +44,8 @@ private:
   void publish_charge_delay(const can_frame& frame) const;
   void publish_charge_voltage(const can_frame& frame) const;
   void publish_safety_lidar(const can_frame& frame) const;
+  void publish_temperature(const can_frame& frame) const;
   ros::Publisher pub_bumper, pub_emergency_switch, pub_emergency_state, pub_charge, pub_power, pub_charge_delay,
-      pub_charge_voltage, pub_safety_lidar;
+      pub_charge_voltage, pub_safety_lidar, pub_temperature;
   static constexpr uint32_t queue_size{ 10 };
 };


### PR DESCRIPTION
## Close Ticket

AMRSW-2054

## Description

Publish properties which are connector temperature and state of health for hardware setup.

## Testing

AMR used: es09

- [x] state_of_health is published 
- [x] connector temperatures are published

Logs which include connector temperature and state of health are following.

**/sensor_set/battery**
```
root@v710es09:/space# rostopic echo -n 1 /sensor_set/battery
state:
  header:
    seq: 0
    stamp:
      secs: 0
      nsecs:         0
    frame_id: ''
  voltage: 26.227001190185547
  temperature: 2.2899999618530273
  current: -1.7400000095367432
  charge: 39.37999725341797
  capacity: 48.0
  design_capacity: 48.0
  percentage: 0.8199999928474426
  power_supply_status: 2
  power_supply_health: 1
  power_supply_technology: 2
  present: True
  cell_voltage: [3.2750000953674316, 3.2860002517700195]
  cell_temperature: [2.309999942779541, 2.2799999713897705]
  location: "0"
  serial_number: "0076"
temps: []
state_of_health: 100
---
```

** /sensor_set/temperature**
```
root@v710es09:/space# rostopic echo -n 1 /sensor_set/temperature
main:
  header:
    seq: 0
    stamp:
      secs: 0
      nsecs:         0
    frame_id: ''
  temperature: 0.0
  variance: 0.0
power:
  header:
    seq: 0
    stamp:
      secs: 0
      nsecs:         0
    frame_id: ''
  temperature: 0.0
  variance: 0.0
linear_actuator_center:
  header:
    seq: 0
    stamp:
      secs: 0
      nsecs:         0
    frame_id: ''
  temperature: 0.0
  variance: 0.0
linear_actuator_left:
  header:
    seq: 0
    stamp:
      secs: 0
      nsecs:         0
    frame_id: ''
  temperature: 0.0
  variance: 0.0
linear_actuator_right:
  header:
    seq: 0
    stamp:
      secs: 0
      nsecs:         0
    frame_id: ''
  temperature: 0.0
  variance: 0.0
charge_plus:
  header:
    seq: 0
    stamp:
      secs: 0
      nsecs:         0
    frame_id: ''
  temperature: 28.0
  variance: 0.0
charge_minus:
  header:
    seq: 0
    stamp:
      secs: 0
      nsecs:         0
    frame_id: ''
  temperature: 25.0
  variance: 0.0
---
```

## Dependent PRs (if any)

https://github.com/LexxPluss/LexxHard-SensorControlBoard-Firmware/pull/81