### PR TITLE
style: format the twelve unformatted baseline files (CI gate prerequisite)

### DIFF
--- a/src/canif.cpp
+++ b/src/canif.cpp
@@ -34,8 +34,7 @@
 #include <iostream>
 #include "canif.hpp"
 
-canif::canif(queue_type& q)
-  : queue{&q}
+canif::canif(queue_type& q) : queue{ &q }
 {
 }
 

--- a/src/canif.hpp
+++ b/src/canif.hpp
@@ -52,6 +52,6 @@ public:
   int send(const can_frame& frame) const;
 
 private:
-  queue_type* queue{nullptr};
-  int sock{-1};
+  queue_type* queue{ nullptr };
+  int sock{ -1 };
 };

--- a/src/devif.cpp
+++ b/src/devif.cpp
@@ -53,13 +53,27 @@ int configure_tty(int fd, uint32_t baudrate)
   speed_t speed;
   switch (baudrate)
   {
-    case 9600:   speed = B9600;   break;
-    case 19200:  speed = B19200;  break;
-    case 38400:  speed = B38400;  break;
-    case 57600:  speed = B57600;  break;
-    case 115200: speed = B115200; break;
-    case 230400: speed = B230400; break;
-    case 460800: speed = B460800; break;
+    case 9600:
+      speed = B9600;
+      break;
+    case 19200:
+      speed = B19200;
+      break;
+    case 38400:
+      speed = B38400;
+      break;
+    case 57600:
+      speed = B57600;
+      break;
+    case 115200:
+      speed = B115200;
+      break;
+    case 230400:
+      speed = B230400;
+      break;
+    case 460800:
+      speed = B460800;
+      break;
     default:
       std::cerr << "Unsupported baudrate: " << baudrate << std::endl;
       return -1;
@@ -92,8 +106,7 @@ int configure_tty(int fd, uint32_t baudrate)
 
 }  // namespace
 
-devif::devif(queue_type& queue)
-  : queue{&queue}
+devif::devif(queue_type& queue) : queue{ &queue }
 {
 }
 
@@ -140,14 +153,14 @@ int devif::add_can(const std::string& ifname, const can_filter* filter, size_t n
     return -1;
   }
 
-  if (unsigned long nonblock{1}; ioctl(sock, FIONBIO, &nonblock) < 0)
+  if (unsigned long nonblock{ 1 }; ioctl(sock, FIONBIO, &nonblock) < 0)
   {
     std::cerr << "ioctl(FIONBIO) failed" << std::endl;
     close(sock);
     return -1;
   }
 
-  can_devices.push_back({sock});
+  can_devices.push_back({ sock });
   return 0;
 }
 
@@ -166,7 +179,7 @@ int devif::add_uart(const std::string& device, uint32_t baudrate)
     return -1;
   }
 
-  uart_devices.push_back({fd, {}});
+  uart_devices.push_back({ fd, {} });
   return 0;
 }
 
@@ -195,7 +208,7 @@ void devif::term()
 
 int devif::poll(int timeout_ms)
 {
-  if(!queue)
+  if (!queue)
   {
     return 0;
   }
@@ -205,11 +218,11 @@ int devif::poll(int timeout_ms)
 
   for (const auto& dev : can_devices)
   {
-    fds.push_back({dev.fd, POLLIN, 0});
+    fds.push_back({ dev.fd, POLLIN, 0 });
   }
   for (const auto& dev : uart_devices)
   {
-    fds.push_back({dev.fd, POLLIN, 0});
+    fds.push_back({ dev.fd, POLLIN, 0 });
   }
 
   if (fds.empty())
@@ -270,7 +283,7 @@ int devif::read_can(can_device& dev)
       return -1;
     }
 
-    if (!queue->push(can_message{frame}))
+    if (!queue->push(can_message{ frame }))
     {
       std::cerr << "CAN queue full, dropping frame" << std::endl;
     }
@@ -314,10 +327,10 @@ int devif::read_uart(uart_device& dev)
         packet.pop_back();
         if (slip_decoder::verify_parity(packet, parity))
         {
-          if (!queue->push(uart_message{std::move(packet)}))
-	  {
+          if (!queue->push(uart_message{ std::move(packet) }))
+          {
             std::cerr << "UART queue full, dropping packet" << std::endl;
-	  }
+          }
         }
         else
         {

--- a/src/devif.hpp
+++ b/src/devif.hpp
@@ -69,19 +69,19 @@ public:
 private:
   struct can_device
   {
-    int fd{-1};
+    int fd{ -1 };
   };
 
   struct uart_device
   {
-    int fd{-1};
+    int fd{ -1 };
     slip_decoder decoder;
   };
 
   int read_can(can_device& dev);
   int read_uart(uart_device& dev);
 
-  queue_type* queue{nullptr};
+  queue_type* queue{ nullptr };
   std::vector<can_device> can_devices;
   std::vector<uart_device> uart_devices;
 };

--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -48,8 +48,16 @@ class handler
 {
 public:
   handler(ros::NodeHandle& n, ros::NodeHandle& pn)
-    : actuator{n, pn}, bmu{n}, board{n}, dfu{n}, imu{n}, pgv{n}, uss{n},
-      gpio{n}, tug_encoder{n}, tof{n}
+    : actuator{ n, pn }
+    , bmu{ n }
+    , board{ n }
+    , dfu{ n }
+    , imu{ n }
+    , pgv{ n }
+    , uss{ n }
+    , gpio{ n }
+    , tug_encoder{ n }
+    , tof{ n }
   {
   }
 
@@ -57,21 +65,32 @@ public:
   {
     switch (frame.can_id)
     {
-      case 0x100: case 0x101: case 0x103:
-      case 0x110: case 0x111: case 0x112: case 0x113:
-      case 0x120: case 0x130:
+      case 0x100:
+      case 0x101:
+      case 0x103:
+      case 0x110:
+      case 0x111:
+      case 0x112:
+      case 0x113:
+      case 0x120:
+      case 0x130:
         bmu.handle(frame);
         break;
-      case 0x200: case 0x201: case 0x202:
+      case 0x200:
+      case 0x201:
+      case 0x202:
         pgv.handle(frame);
         break;
       case 0x204:
         uss.handle(frame);
         break;
-      case 0x206: case 0x207:
+      case 0x206:
+      case 0x207:
         imu.handle(frame);
         break;
-      case 0x209: case 0x20a: case 0x213:
+      case 0x209:
+      case 0x20a:
+      case 0x213:
         actuator.handle(frame);
         break;
       case 0x20c:
@@ -121,20 +140,18 @@ int main(int argc, char* argv[])
   std::string const tof_uart_port = pn.param<std::string>("tof_sensor_board_uart_port", "/dev/ttyACM0");
   uint32_t const tof_baudrate = static_cast<uint32_t>(pn.param<int>("tof_sensor_board_baudrate", 115200));
 
-  handler handler{n, pn};
+  handler handler{ n, pn };
 
   // CAN setup
   canif::queue_type can_queue;
-  canif can{can_queue};
+  canif can{ can_queue };
   can_filter filter[]{
-      {0x100, CAN_SFF_MASK}, {0x101, CAN_SFF_MASK}, {0x103, CAN_SFF_MASK},
-      {0x110, CAN_SFF_MASK}, {0x111, CAN_SFF_MASK}, {0x112, CAN_SFF_MASK},
-      {0x113, CAN_SFF_MASK}, {0x120, CAN_SFF_MASK}, {0x130, CAN_SFF_MASK},
-      {0x200, CAN_SFF_MASK}, {0x201, CAN_SFF_MASK}, {0x202, CAN_SFF_MASK},
-      {0x204, CAN_SFF_MASK}, {0x206, CAN_SFF_MASK}, {0x207, CAN_SFF_MASK},
-      {0x209, CAN_SFF_MASK}, {0x20a, CAN_SFF_MASK}, {0x20c, CAN_SFF_MASK},
-      {0x20e, CAN_SFF_MASK}, {0x210, CAN_SFF_MASK}, {0x212, CAN_SFF_MASK},
-      {0x213, CAN_SFF_MASK},
+    { 0x100, CAN_SFF_MASK }, { 0x101, CAN_SFF_MASK }, { 0x103, CAN_SFF_MASK }, { 0x110, CAN_SFF_MASK },
+    { 0x111, CAN_SFF_MASK }, { 0x112, CAN_SFF_MASK }, { 0x113, CAN_SFF_MASK }, { 0x120, CAN_SFF_MASK },
+    { 0x130, CAN_SFF_MASK }, { 0x200, CAN_SFF_MASK }, { 0x201, CAN_SFF_MASK }, { 0x202, CAN_SFF_MASK },
+    { 0x204, CAN_SFF_MASK }, { 0x206, CAN_SFF_MASK }, { 0x207, CAN_SFF_MASK }, { 0x209, CAN_SFF_MASK },
+    { 0x20a, CAN_SFF_MASK }, { 0x20c, CAN_SFF_MASK }, { 0x20e, CAN_SFF_MASK }, { 0x210, CAN_SFF_MASK },
+    { 0x212, CAN_SFF_MASK }, { 0x213, CAN_SFF_MASK },
   };
   if (can.init("can1", filter, sizeof filter) < 0)
   {
@@ -143,7 +160,7 @@ int main(int argc, char* argv[])
 
   // UART setup
   uartif::queue_type uart_queue;
-  uartif uart{tof_uart_port, tof_baudrate, uart_queue};
+  uartif uart{ tof_uart_port, tof_baudrate, uart_queue };
   if (use_tof_sensor_board)
   {
     if (uart.init() < 0)
@@ -153,19 +170,19 @@ int main(int argc, char* argv[])
   }
 
   // Start I/O threads
-  std::atomic<bool> running{true};
-  std::thread can_thread{[&] {
+  std::atomic<bool> running{ true };
+  std::thread can_thread{ [&] {
     while (running.load(std::memory_order_relaxed))
     {
       can.poll(1);
     }
-  }};
-  std::thread uart_thread{[&] {
+  } };
+  std::thread uart_thread{ [&] {
     while (running.load(std::memory_order_relaxed))
     {
       uart.poll(1);
     }
-  }};
+  } };
 
   // Main loop
   while (ros::ok())

--- a/src/receiver_tof.cpp
+++ b/src/receiver_tof.cpp
@@ -33,86 +33,88 @@
 
 namespace
 {
-    constexpr uint8_t PKT_TOF_DATA = 0x01;
-    constexpr uint8_t TOF_PACKET_HEADER_SIZE = 7;
+constexpr uint8_t PKT_TOF_DATA = 0x01;
+constexpr uint8_t TOF_PACKET_HEADER_SIZE = 7;
 
-    struct __attribute__((packed)) ToF_ZoneResult {
-    uint8_t num_of_targets;
-        uint32_t distance[4];
-        uint8_t status[4];
-    };
-    struct __attribute__((packed)) ToF_Packet {
-        uint8_t type;
-        uint8_t sensor_id;
-        uint32_t timestamp_ms;
-        uint8_t num_of_zones;
-    ToF_ZoneResult zone_results[64];
-    };
+struct __attribute__((packed)) ToF_ZoneResult
+{
+  uint8_t num_of_targets;
+  uint32_t distance[4];
+  uint8_t status[4];
+};
+struct __attribute__((packed)) ToF_Packet
+{
+  uint8_t type;
+  uint8_t sensor_id;
+  uint32_t timestamp_ms;
+  uint8_t num_of_zones;
+  ToF_ZoneResult zone_results[64];
+};
 
-    uint32_t read_le32(const std::vector<uint8_t>& packet, size_t offset)
+uint32_t read_le32(const std::vector<uint8_t>& packet, size_t offset)
+{
+  return packet[offset] | (packet[offset + 1] << 8) | (packet[offset + 2] << 16) | (packet[offset + 3] << 24);
+}
+
+float conv_from_raw_distance(uint32_t raw_distance)
+{
+  return static_cast<float>(raw_distance) * 0.001f;  // Convert mm to meters
+}
+
+std::optional<ToF_Packet> parse_frame(const std::vector<uint8_t>& frame)
+{
+  if (frame.size() < TOF_PACKET_HEADER_SIZE)
+  {
+    std::cerr << "ToF packet too short: " << frame.size() << " bytes" << std::endl;
+    return std::nullopt;
+  }
+
+  ToF_Packet packet{
+    .type = frame[0],
+    .sensor_id = frame[1],
+    .timestamp_ms = read_le32(frame, 2),
+    .num_of_zones = frame[6],
+  };
+
+  size_t offset = TOF_PACKET_HEADER_SIZE;
+  for (int i = 0; i < packet.num_of_zones; ++i)
+  {
+    packet.zone_results[i].num_of_targets = frame[offset++];
+    for (int j = 0; j < packet.zone_results[i].num_of_targets; ++j)
     {
-      return packet[offset] | (packet[offset+1] << 8) | (packet[offset+2] << 16) | (packet[offset+3] << 24);
+      packet.zone_results[i].distance[j] = read_le32(frame, offset);
+      offset += 4;
+      packet.zone_results[i].status[j] = frame[offset++];
+    }
+  }
+
+  return packet;
+}
+
+bool decode(std_msgs::Float32MultiArray& msg, ToF_Packet const& packet)
+{
+  if (packet.type != PKT_TOF_DATA)
+  {
+    std::cerr << "Unknown ToF packet type: " << static_cast<int>(packet.type) << std::endl;
+    return false;
+  }
+
+  msg.data.clear();
+  for (uint8_t i = 0; i < packet.num_of_zones; ++i)
+  {
+    if (packet.zone_results[i].num_of_targets == 0)
+    {
+      msg.data.push_back(-1.0);
     }
 
-    float conv_from_raw_distance(uint32_t raw_distance)
+    for (uint8_t j = 0; j < packet.zone_results[i].num_of_targets; ++j)
     {
-        return static_cast<float>(raw_distance) * 0.001f; // Convert mm to meters
+      msg.data.push_back(conv_from_raw_distance(packet.zone_results[i].distance[j]));
     }
+  }
 
-    std::optional<ToF_Packet> parse_frame(const std::vector<uint8_t>& frame)
-    {
-        if (frame.size() < TOF_PACKET_HEADER_SIZE)
-        {
-            std::cerr << "ToF packet too short: " << frame.size() << " bytes" << std::endl;
-            return std::nullopt;
-        }
-
-        ToF_Packet packet{
-            .type = frame[0],
-            .sensor_id = frame[1],
-            .timestamp_ms = read_le32(frame, 2),
-            .num_of_zones = frame[6],
-        };
-
-    size_t offset = TOF_PACKET_HEADER_SIZE;
-    for(int i = 0;i < packet.num_of_zones; ++i)
-    {
-        packet.zone_results[i].num_of_targets = frame[offset++];
-        for(int j = 0; j < packet.zone_results[i].num_of_targets; ++j)
-        {
-        packet.zone_results[i].distance[j] = read_le32(frame, offset);
-        offset += 4;
-        packet.zone_results[i].status[j] = frame[offset++];
-        }
-    }
-
-        return packet;
-    }
-
-    bool decode(std_msgs::Float32MultiArray& msg, ToF_Packet const& packet)
-    {
-        if (packet.type != PKT_TOF_DATA)
-        {
-            std::cerr << "Unknown ToF packet type: " << static_cast<int>(packet.type) << std::endl;
-            return false;
-        }
-
-        msg.data.clear();
-        for (uint8_t i = 0; i < packet.num_of_zones; ++i)
-        {
-            if(packet.zone_results[i].num_of_targets == 0)
-            {
-                msg.data.push_back(-1.0);
-            }
-
-            for (uint8_t j = 0; j < packet.zone_results[i].num_of_targets; ++j)
-            {
-                msg.data.push_back(conv_from_raw_distance(packet.zone_results[i].distance[j]));
-            }
-        }
-
-        return true;
-    }
+  return true;
+}
 }  // namespace
 
 receiver_tof::receiver_tof(ros::NodeHandle& n)
@@ -126,36 +128,35 @@ receiver_tof::receiver_tof(ros::NodeHandle& n)
 void receiver_tof::handle(const std::vector<uint8_t>& frame)
 {
   const std::optional<ToF_Packet> packet = parse_frame(frame);
-  if(!packet)
+  if (!packet)
   {
     return;
   }
 
   std_msgs::Float32MultiArray msg;
-  if(!decode(msg, *packet))
+  if (!decode(msg, *packet))
   {
     return;
   }
 
-  if(packet->sensor_id == 0)
+  if (packet->sensor_id == 0)
   {
     pub_tof_front.publish(msg);
   }
-  else if(packet->sensor_id == 1)
+  else if (packet->sensor_id == 1)
   {
     pub_tof_rear.publish(msg);
   }
-  else if(packet->sensor_id == 2)
+  else if (packet->sensor_id == 2)
   {
     pub_low_object_left.publish(msg);
   }
-  else if(packet->sensor_id == 3)
+  else if (packet->sensor_id == 3)
   {
     pub_low_object_right.publish(msg);
   }
   else
   {
-    std::cerr << "Invalid sensor ID in ToF packet: "
-              << static_cast<int>(packet->sensor_id) << std::endl;
+    std::cerr << "Invalid sensor ID in ToF packet: " << static_cast<int>(packet->sensor_id) << std::endl;
   }
 }

--- a/src/receiver_tof.hpp
+++ b/src/receiver_tof.hpp
@@ -36,7 +36,7 @@ public:
   void handle(const std::vector<uint8_t>& packet);
 
 private:
-  static constexpr int queue_size{10};
+  static constexpr int queue_size{ 10 };
   ros::Publisher pub_tof_front;
   ros::Publisher pub_tof_rear;
   ros::Publisher pub_low_object_left;

--- a/src/slip_decoder.cpp
+++ b/src/slip_decoder.cpp
@@ -66,9 +66,7 @@ bool slip_decoder::decode_byte(uint8_t byte, std::vector<uint8_t>& packet)
     else
     {
       // Invalid escape sequence - clear buffer to resync
-      std::cerr << "SLIP: Invalid escape sequence (0x"
-                << std::hex << static_cast<int>(byte) << std::dec
-                << "), resync"
+      std::cerr << "SLIP: Invalid escape sequence (0x" << std::hex << static_cast<int>(byte) << std::dec << "), resync"
                 << std::endl;
       buffer.clear();
     }

--- a/src/slip_decoder.hpp
+++ b/src/slip_decoder.hpp
@@ -38,7 +38,7 @@ public:
 
 private:
   std::vector<uint8_t> buffer;
-  bool escape_next{false};
+  bool escape_next{ false };
 
   static constexpr uint8_t SLIP_END = 0xC0;
   static constexpr uint8_t SLIP_ESC = 0xDB;

--- a/src/spsc_queue.hpp
+++ b/src/spsc_queue.hpp
@@ -73,6 +73,6 @@ public:
 
 private:
   std::array<T, Capacity> buffer;
-  std::atomic<size_t> head{0};
-  std::atomic<size_t> tail{0};
+  std::atomic<size_t> head{ 0 };
+  std::atomic<size_t> tail{ 0 };
 };

--- a/src/uartif.cpp
+++ b/src/uartif.cpp
@@ -49,13 +49,27 @@ int configure_tty(int fd, int baudrate)
   speed_t speed = B115200;
   switch (baudrate)
   {
-    case 9600: speed = B9600; break;
-    case 19200: speed = B19200; break;
-    case 38400: speed = B38400; break;
-    case 57600: speed = B57600; break;
-    case 115200: speed = B115200; break;
-    case 230400: speed = B230400; break;
-    case 460800: speed = B460800; break;
+    case 9600:
+      speed = B9600;
+      break;
+    case 19200:
+      speed = B19200;
+      break;
+    case 38400:
+      speed = B38400;
+      break;
+    case 57600:
+      speed = B57600;
+      break;
+    case 115200:
+      speed = B115200;
+      break;
+    case 230400:
+      speed = B230400;
+      break;
+    case 460800:
+      speed = B460800;
+      break;
     default:
       std::cerr << "Unsupported baudrate: " << baudrate << std::endl;
       return -1;
@@ -64,8 +78,8 @@ int configure_tty(int fd, int baudrate)
   cfsetispeed(&tty, speed);
 
   // Configure 8N1
-  tty.c_cflag &= ~PARENB;         // No parity
-  tty.c_cflag &= ~CSTOPB;         // 1 stop bit
+  tty.c_cflag &= ~PARENB;  // No parity
+  tty.c_cflag &= ~CSTOPB;  // 1 stop bit
   tty.c_cflag &= ~CSIZE;
   tty.c_cflag |= CS8;             // 8 data bits
   tty.c_cflag &= ~CRTSCTS;        // No hardware flow control
@@ -93,9 +107,9 @@ int configure_tty(int fd, int baudrate)
 
 bool has_data(int fd, int timeout_ms)
 {
-  pollfd fds{.fd{fd}, .events{POLLIN}};
-  
-  if (auto ret{::poll(&fds, 1, timeout_ms)}; ret < 0)
+  pollfd fds{ .fd{ fd }, .events{ POLLIN } };
+
+  if (auto ret{ ::poll(&fds, 1, timeout_ms) }; ret < 0)
   {
     if (errno != EINTR)
     {
@@ -108,22 +122,18 @@ bool has_data(int fd, int timeout_ms)
     // Timeout - no data available
     return false;
   }
-  
+
   return true;
 }
 
 }  // namespace
 
-uartif::uartif(const std::string& device, uint32_t baudrate)
-  : device{device}
-  , baudrate{baudrate}
+uartif::uartif(const std::string& device, uint32_t baudrate) : device{ device }, baudrate{ baudrate }
 {
 }
 
 uartif::uartif(const std::string& device, uint32_t baudrate, queue_type& q)
-  : device{device}
-  , baudrate{baudrate}
-  , queue{&q}
+  : device{ device }, baudrate{ baudrate }, queue{ &q }
 {
 }
 
@@ -148,7 +158,7 @@ int uartif::init()
   }
 
   decoder.reset();
-  
+
   return 0;
 }
 
@@ -169,7 +179,7 @@ int uartif::poll(int timeout_ms) const
   {
     return 0;
   }
-  
+
   if (!has_data(fd, timeout_ms))
   {
     return 0;
@@ -210,9 +220,9 @@ int uartif::poll(int timeout_ms) const
         if (slip_decoder::verify_parity(packet, parity))
         {
           if (!queue->push(std::move(packet)))
-	  {
+          {
             std::cerr << "UART queue full, dropping packet" << std::endl;
-	  }
+          }
         }
         else
         {

--- a/src/uartif.hpp
+++ b/src/uartif.hpp
@@ -51,7 +51,7 @@ public:
 private:
   const std::string device;
   const uint32_t baudrate;
-  int fd{-1};
-  queue_type* queue{nullptr};
+  int fd{ -1 };
+  queue_type* queue{ nullptr };
   mutable slip_decoder decoder;
 };


### PR DESCRIPTION
## Close Ticket

AMRSW-2322 (prerequisite, not the feature itself)

## Description

Formatting only, for the twelve files that were already unformatted on
`prod/pj-paco-xxxx-joint-1`.

CI runs `clang-format -i` over every `.h`, `.hpp` and `.cpp` in the repository with an
explicitly named style file and then fails on any diff — but it triggers **only on `main`**,
so it does not run on a pull request into this branch, including this one. This PR is
therefore pre-emptive rather than unblocking: the twelve files are unformatted today, so the
first time this line of work reaches `main` the gate fails on content nobody in that PR
touched. Fixing it here keeps that failure from landing on an unrelated review.

No identifier, no control flow and no comment text is changed — only line re-wrapping.
Running the CI command after this commit produces no diff at all.

## Testing

AMR used: **none — formatting only.**

- [x] `find . -name '*.h' -o -name '*.hpp' -o -name '*.cpp' | xargs clang-format -i --style=file:./util/workspace/.clang-format` then `git diff --exit-code` — clean, so the style job would pass
- [x] `catkin_make run_tests_scbdriver` — 60 tests, 0 failures (32 assembler, 28 pipeline; 2 capture-replay cases skipped)
- [x] clang-format 14, matching the version CI installs on ubuntu-22.04

## Visualization

N/A

## Dependent PRs (if any)

Related to `feature/AMRSW-2322-tof-can-transport`, whose own sources are formatted against this
baseline. Not a hard prerequisite, since CI does not run on either PR's base.
